### PR TITLE
Suss uni buttons PR

### DIFF
--- a/app/assets/javascripts/shf_application.js
+++ b/app/assets/javascripts/shf_application.js
@@ -28,7 +28,7 @@ $(function() {
 
 function enable_submit_button () {
   $('.app-submit').prop('disabled', false);
-  $('.submit-button-explain').addClass('hide');
+  $('.submit-button-explain').hide();
 }
 
 function remove_change_callback_for_radio_buttons (radio_buttons) {


### PR DESCRIPTION
This allows the submit-button-enable instruction on the app form to be hidden when the user selects a file delivery method.

See other comments in the PR.

